### PR TITLE
dyanmically load webpack generated client path if it is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ generated
 
 # Ignore .env configuration files
 .env
+
+#ignore generated assets
+webpack-assets.json

--- a/gulpfile.js/config/webpack.js
+++ b/gulpfile.js/config/webpack.js
@@ -1,5 +1,6 @@
 var paths = require('./');
 var webpack = require('webpack');
+var AssetsPlugin = require('assets-webpack-plugin');
 
 module.exports = function (env) {
 
@@ -29,7 +30,7 @@ module.exports = function (env) {
 
         output: {
             path: jsDest,
-            filename: '[name].js',
+            filename: '[name].[hash].js',
             publicPath: publicPath
         },
 
@@ -73,6 +74,7 @@ module.exports = function (env) {
 
     if (env === 'production' || env === 'staging') {
         webpackConfig.plugins.push(
+            new AssetsPlugin({fullPath: true}),
             new webpack.DefinePlugin({
                 'process.env': {
                     'NODE_ENV': JSON.stringify('production')

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "develop": "node server.js | gulp build:development"
   },
   "dependencies": {
+    "assets-webpack-plugin": "^3.2.0",
     "axios": "^0.8.1",
     "babel": "^6.3.26",
     "babel-core": "^6.4.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,7 @@
 var shortid = require('shortid');
 
+
+
 module.exports = function( router, models ) {
     /**
      * On the intital route, we should make a new "bin" and create the first revision
@@ -68,6 +70,7 @@ module.exports = function( router, models ) {
      * This route will load a bin and a revision by ID
      */
     router.get('/:bin/:revision', function *() {
+
 
         var bin = yield models.bin
             .findOne({'id': this.params.bin});

--- a/views/index.html
+++ b/views/index.html
@@ -15,5 +15,5 @@
     window.cssResources= {{cssResources | json | raw}};
 </script>
 <script src="/javascripts/socket.io.js" defer></script>
-<script src="/javascripts/client.js" defer></script>
+<script src="{{client}}" defer></script>
 {% endblock %}


### PR DESCRIPTION
Fixes #5, on the production build, hash the webpack built client.js file. Added a middleware to check for this manifest and update the view state appropriately 
